### PR TITLE
Make readme aware of flink.sh and flink-shaded.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # Flink Utilities
 
-* `verify-flink-release/main.sh`: This script tries to automate steps of the [verification process](https://cwiki.apache.org/confluence/display/FLINK/Verifying+a+Flink+Release) within Apache Flink. Run `./verify-flink-release/main.sh` to get further details on how to use the script.
+* `verify-flink-release/flink.sh`: This script tries to automate steps of the [verification process](https://cwiki.apache.org/confluence/display/FLINK/Verifying+a+Flink+Release) within Apache Flink. Run `./verify-flink-release/flink.sh` to get further details on how to use the script.
+* `verify-flink-release/flink-shaded.sh`: Similar script to check [flink-shaded|https://github.com/apache/flink-shaded] releases


### PR DESCRIPTION
README seems to be outdated and references to `main.sh` which is not present in repo